### PR TITLE
Speed up Babel builds, and favor include over exclude

### DIFF
--- a/theme/webpack.config.js
+++ b/theme/webpack.config.js
@@ -41,12 +41,12 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    exclude: /node_modules/,
+                    include: dirSource,
                     test: /\.js$/,
                     use: [
                         {
                             loader: 'babel-loader',
-                            options: babelOptions
+                            options: { ...babelOptions, cacheDirectory: true }
                         }
                     ]
                 },


### PR DESCRIPTION
1. `cacheDirectory` tells `babel-loader` to cache to disk between builds. Faster starts in dev
2. Using `include` speeds up builds as they grow (as opposed to an exclude), and sets us up for when we need to compile JSX from `peregrine` in `node_modules` (necessary for the way extensions and `mid` props work)