### PR TITLE
Change webpack context to directory root

### DIFF
--- a/theme/webpack.config.js
+++ b/theme/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = env => {
 
     // create the default config for development-like environments
     const config = {
-        context: dirSource,
+        context: dirRoot,
         entry: {
             client: resolve(dirSource, 'index.js')
         },


### PR DESCRIPTION
[Our webpack plugin](https://github.com/magento-research/anhinga/blob/b32c79527483335017c0a81f94fda9e8572dcfa3/docs/webpack-magento-root-components-chunks-plugin.md) let's a user define a `rootComponentsDirs` (default is `./src/RootComponents`), where relative paths are based off the of project context (common pattern in webpack plugins).

It's unusual in most webpack apps to use `context` as the source root, instead of the application root. Someone passing in `src/Roots` would be surprised that it ended up at `src/src/Roots`.

`context` is also used to resolve things besides source files (used to resolve loaders, which someone may have in a folder in their theme).