### PR TITLE
Fix node_modules lookup in webpack config

### DIFF
--- a/theme/webpack.config.js
+++ b/theme/webpack.config.js
@@ -28,7 +28,6 @@ dotenv.config();
 const dirRoot = resolve(__dirname);
 const dirSource = resolve(dirRoot, 'src');
 const dirOutput = resolve(dirRoot, 'web/js');
-const dirModules = resolve(dirRoot, 'node_modules');
 
 // ensure env paths are valid URLs
 const mockImagesPath = new URL(process.env.MOCK_IMAGES_PATH);
@@ -100,7 +99,7 @@ module.exports = async env => {
             ]
         },
         resolve: {
-            modules: [dirRoot, dirModules],
+            modules: [dirRoot, 'node_modules'],
             mainFiles: ['index'],
             extensions: ['.js']
         },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5233399/37108833-e8240e2c-21fd-11e8-81d7-f05c4454a0f1.png)

Right now, with our config, webpack only finds transitive dependencies if they've been hoisted, but breaks for deps that can't be hoisted.