### PR TITLE
Update to latest Peregrine for Routing

### DIFF
--- a/theme/.gitignore
+++ b/theme/.gitignore
@@ -1,7 +1,6 @@
 node_modules
 npm-debug.log
-web/**/*.js
-web/**/*.js.map
+web/
 coverage
 .DS_Store
 .env

--- a/theme/package-lock.json
+++ b/theme/package-lock.json
@@ -188,9 +188,9 @@
       "dev": true
     },
     "@magento/peregrine": {
-      "version": "0.1.1-alpha",
-      "resolved": "https://registry.npmjs.org/@magento/peregrine/-/peregrine-0.1.1-alpha.tgz",
-      "integrity": "sha512-RoixGjXZz+27Pgik5nQM5P4gJvBl69tCOCUMoKij5hlJE7cv6pGC7a3BPY6ZgCF7rP70NjOSu+9l+Z0JvxhtbA=="
+      "version": "0.1.5-alpha",
+      "resolved": "https://registry.npmjs.org/@magento/peregrine/-/peregrine-0.1.5-alpha.tgz",
+      "integrity": "sha512-K2wDfhiCBeEn8wKXEgB/jaBs2n2V058hP32AkDdyfYGi5w7DkgKSGIVlKhlqBr+enkuj071RpXLnjZc486NlkA=="
     },
     "@magento/workbox-webpack-plugin": {
       "version": "3.0.0-alpha-magento.1",

--- a/theme/package.json
+++ b/theme/package.json
@@ -24,7 +24,7 @@
     "test:dev": "jest --watch"
   },
   "dependencies": {
-    "@magento/peregrine": "^0.1.1-alpha",
+    "@magento/peregrine": "^0.1.5-alpha",
     "babel-runtime": "^6.26.0",
     "dotenv": "^4.0.0",
     "feather-icons": "^4.6.0",

--- a/theme/src/index.js
+++ b/theme/src/index.js
@@ -1,10 +1,13 @@
 import Peregrine from '@magento/peregrine';
 
-import getNamedExport from 'src/util/getNamedExport';
 import './index.css';
 
-const app = new Peregrine();
-const container = document.getElementById('root');
+const app = new Peregrine({
+    apiBase: new URL('/graphql', location.origin).toString(),
+    __tmp_webpack_public_path__: __webpack_public_path__
+});
+
+app.mount(document.getElementById('root'));
 
 if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
@@ -18,14 +21,5 @@ if ('serviceWorker' in navigator) {
             });
     });
 }
-
-getNamedExport(import('src/components/App'))
-    .then(App => {
-        app.component = App;
-        app.mount(container);
-    })
-    .catch(error => {
-        throw error;
-    });
 
 export default app;


### PR DESCRIPTION
Updates to your local necessary:

1. Be running a branch of Magento that has the `/graphql` endpoint with the `urlResolver` query

When you access the store once this is merged, you'll have to start visiting real routes, since the Category page will no longer be hard-coded.