### PR TITLE
Fix vendor.js file error when creating the build file 

### DIFF
--- a/theme-frontend-venia/webpack.config.js
+++ b/theme-frontend-venia/webpack.config.js
@@ -121,7 +121,7 @@ module.exports = async function(env) {
             new webpack.HotModuleReplacementPlugin()
         );
     } else if (env.phase === 'production') {
-        config.vendor.entry = libs;
+        config.entry.vendor = libs;
         config.plugins.push(
             new webpack.optimize.CommonsChunkPlugin({
                 names: ['vendor']


### PR DESCRIPTION
Previously, when I ran `npm run build`, I would get an error stating that it's not able to create 'entry' against the null value config.vendor. It seems the words were the wrong way round in the webpack config and it should be `config.entry.vendor` rather than `config.vendor.entry`.