### PR TITLE
chore(deps): update @magento-pwa-buildpack dep to get bugfix

### DIFF
--- a/theme-frontend-venia/package-lock.json
+++ b/theme-frontend-venia/package-lock.json
@@ -169,9 +169,9 @@
       }
     },
     "@magento/devcert": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@magento/devcert/-/devcert-0.5.0.tgz",
-      "integrity": "sha512-estWX4o+h6WolpLI+Tdn980zQiSnI+4aC4HF7mwwdziF9lynYIfZLyp8ESuNfpmzWqHYbl8/yJPhvg6iIEEU4g==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@magento/devcert/-/devcert-0.7.0.tgz",
+      "integrity": "sha512-XkyMS7b966dnlRdrlTZgUTFGRfS79DVSxmGKS6HBWwXI0ihEWs/7O20UDqQ+qp2iTx92Wevh8mudtPA+PzYRhg==",
       "dev": true,
       "requires": {
         "command-exists": "^1.2.2",
@@ -202,12 +202,12 @@
       "integrity": "sha512-nmmgZPGMIgkQtENfxxEOre0gPq1SgkED0K8hJqeyv2LE7BlQyXE73IVt/H90lLoZpud7L8zqB32epkYFv5N6wQ=="
     },
     "@magento/pwa-buildpack": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@magento/pwa-buildpack/-/pwa-buildpack-0.7.1.tgz",
-      "integrity": "sha512-f45xFwJ1NGa6LublWyTTAm/teJ0XDvXmK/ENrBDXW0cMRPlGO/0ccsOM8VY67juOzpLZsOMhzqjBNJjtE4LNCQ==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@magento/pwa-buildpack/-/pwa-buildpack-0.8.2.tgz",
+      "integrity": "sha512-82bbtOEOf1LwP/gOYdxs4krG/BBDY6NUlfYy8D43cq/fhG84XM/GfX3Q+bysrPQuWBuX4Q0rXkDO1pYzNKXmRQ==",
       "dev": true,
       "requires": {
-        "@magento/devcert": "^0.5.0",
+        "@magento/devcert": "^0.7.0",
         "@magento/directive-parser": "^0.1.1",
         "ajv": "^6.1.1",
         "babel-helper-module-imports": "^7.0.0-beta.3",
@@ -220,7 +220,6 @@
         "http-proxy-middleware": "^0.18.0",
         "lodash.get": "^4.4.2",
         "openport": "0.0.4",
-        "sudo-prompt": "^8.1.0",
         "through": "^2.3.8",
         "webpack-sources": "^1.1.0",
         "workbox-webpack-plugin": "^3.0.0-beta.1",
@@ -2790,13 +2789,10 @@
       "dev": true
     },
     "common-tags": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.7.2.tgz",
-      "integrity": "sha512-joj9ZlUOjCrwdbmiLqafeUSgkUM74NqhLsZtSqDmhKudaIY197zTrb8JMl31fMnCUuxwFT23eC/oWvrZzDLRJQ==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0"
-      }
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -6125,18 +6121,38 @@
       "dev": true
     },
     "hostile": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/hostile/-/hostile-1.3.1.tgz",
-      "integrity": "sha512-5AnCyKcIInErGgRGkZ6Cq3BhS0hck9Ruk2ZmRaULSCLdlQ1vcKuJuEu0w+6pkkQ3ZMgCY4k3ra8EmbsMW/JKAw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/hostile/-/hostile-1.3.2.tgz",
+      "integrity": "sha512-wOXjaB9HPLiWw6PvLcuLZomss/tURub44WhReH/3PVmdruUwxYuJAN2TgxYgsWeLOlrM6cnMSait4ERDLckbFA==",
       "dev": true,
       "requires": {
-        "chalk": "^1.0.0",
+        "chalk": "^2.3.1",
         "minimist": "^1.1.0",
         "once": "^1.3.0",
         "split": "^1.0.0",
         "through": "^2.3.4"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -6150,6 +6166,15 @@
           "dev": true,
           "requires": {
             "through": "2"
+          }
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -9078,9 +9103,9 @@
       }
     },
     "moment": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
-      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
       "dev": true
     },
     "move-concurrently": {
@@ -13064,12 +13089,6 @@
         }
       }
     },
-    "sudo-prompt": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-8.2.0.tgz",
-      "integrity": "sha512-n5Nv2lIZaWfVBg10EWC8yaJCB6xV7sEsuaISAVFIS9F4fTRjy/O35A82lkweKuSqQItDlKOGQpTHK9/udQhRRw==",
-      "dev": true
-    },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -14713,9 +14732,9 @@
       }
     },
     "write-file-webpack-plugin": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/write-file-webpack-plugin/-/write-file-webpack-plugin-4.3.1.tgz",
-      "integrity": "sha512-OoA7+uqbAMZa4m3uDexJIJVQ+sMQPGQmfs3ydVLelvtSytDfdLadmimOAaDB0/zqjAOWRs/Y8fJnMPt6OxgQCw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/write-file-webpack-plugin/-/write-file-webpack-plugin-4.3.2.tgz",
+      "integrity": "sha512-xYMlbV2vPXa1MDQ0FYQk/45ELHgLph+vAdxjxWNOVLAZFVpkNadoQralTc1Wiw0wS1lrJhNOMSK6KMC3YdCOLw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.0",

--- a/theme-frontend-venia/package.json
+++ b/theme-frontend-venia/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@magento/eslint-config": "^1.0.0",
-    "@magento/pwa-buildpack": "^0.7.1",
+    "@magento/pwa-buildpack": "^0.8.2",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.1.2",
     "babel-jest": "^22.1.0",


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
[ ] New feature
[ ] Enhancement/Optimization
[ ] Refactor
[x] Bugfix
[ ] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->
## Summary

Upgraded package.json `devDependencies` to use `@magento/pwa-buildpack` at semver `^0.8.2`.
 
When this pull request is merged, it will fix the `npm start` freeze on Linux systems. Because it's in `0.x.x`, even a minor release requires a semver string change to pull it in.
 
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information
Buildpack released [0.8.2](https://github.com/magento-research/pwa-buildpack/releases/tag/v0.8.2).
Because it's in `0.x.x`, even a minor release requires a semver string change to pull it in.
<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/venia-pwa-concept/blob/develop/.github/CONTRIBUTION.md
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->